### PR TITLE
Change BrightCerts to BrightTrust

### DIFF
--- a/config/user.trtl.zone
+++ b/config/user.trtl.zone
@@ -5,6 +5,6 @@
 ; turtleshirtshop       IN        A       164.93.1.31 ; turtleshirtshop.user.trtl
 $ORIGIN user.trtl.
 
-brightcerts             IN        CNAME   brightcerts.whats-in.space. ; Issue #29
+brighttrust             IN        CNAME   brighttrust.whats-in.space. ; Issue #29
 fexra                   IN        A       139.162.155.73 ; Issue #7
 greywolf                IN        A       50.62.67.1 ; Issue #28


### PR DESCRIPTION
Swapping the name of the domain so it makes more sense.