### PR TITLE
Fix W3C errors

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,10 @@
    html5up.net | @ajlkn
    Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
    -->
-<html>
+<html lang="en">
    <head>
       <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+      <meta name="viewport" content="width=device-width" />
 	  
       <title>.trtl TLD Domain Services</title>
       <meta name="description" content="Domain system for .trtl TLD. ">
@@ -51,7 +51,7 @@
          </nav>
          <!-- Header -->
          <header id="header" class="alt">
-            <span class="logo"><img src="images/dot-trtl.svg" alt="" /></span>
+            <span class="logo"><img src="images/dot-trtl.svg" alt=".trtl TLD" /></span>
             <h1>Domain system for .trtl TLD</h1>
          </header>
          <!-- Main -->
@@ -172,7 +172,7 @@
                      <h3>What do I get with a .trtl domain?</h3>
                      <p class="content">For the moment you get either a CNAME or A/AAAA record. Once everything is completely automated we'll looking into offering full sub-domain space. For the moment if you get the-box.trtl then in the future you would have the option to fully use the whole sub-domain. So right now all you'll get is the-box.trtl and be able to point it at an IP address or CNAME.</p>
                      <h3>Can I use LetsEncrypt?</h3>
-                     <p class="content">Certificates are a technical limitation that we haven't overcome at the moment.<br /> Read more about this issue <a href="https://community.letsencrypt.org/t/do-you-support-opennic-top-level-domains/4473 target="_blank"">here</a>.</p>
+                     <p class="content">Certificates are a technical limitation that we haven't overcome at the moment.<br /> Read more about this issue <a href="https://community.letsencrypt.org/t/do-you-support-opennic-top-level-domains/4473" target="_blank">here</a>.</p>
                      <h3>How much are .trtl domains?</h3>
                      <p class="content">Currently our pricing is based on the length of the name, for a one year term. We're always looking at better ways to do things though, so keep your eyes peeled and you just might spot a deal that works for your project.</p>
                      <h3>What's going on with my application?</h3>


### PR DESCRIPTION
**Full list:** https://validator.w3.org/nu/?doc=https%3A%2F%2Fdns.turtlecoin.lol%2F

- No space between attributes.
- Quote " in attribute name. Probable cause: Matching quote missing somewhere earlier.
- Bad value target= for attribute href on element a
- Attribute _blank"" not allowed on element a at this point.
- This document appears to be written in English. Consider adding lang="en" (or variant) to the html start tag.
- Attribute _blank"" is not serializable as XML 1.0.
- Consider avoiding viewport values that prevent users from resizing documents.

## Before:
![image](https://user-images.githubusercontent.com/8020386/94356326-bf1c7980-00bf-11eb-9831-8f51698f1a46.png)

## After:
![image](https://user-images.githubusercontent.com/8020386/94356336-d65b6700-00bf-11eb-803b-bfdeeccb2810.png)